### PR TITLE
Implemented nodeset XML parser along with unit tests

### DIFF
--- a/src/components/NodeTree/index.ts
+++ b/src/components/NodeTree/index.ts
@@ -1,1 +1,0 @@
-export { default } from './NodeTree';

--- a/src/services/nodeset-parser.service.test.ts
+++ b/src/services/nodeset-parser.service.test.ts
@@ -1,0 +1,481 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { NodesetParser } from './nodeset-parser.service';
+import { NodeClass } from '@/types/opcua.types';
+
+describe('NodesetParser', () => {
+  let parser: NodesetParser;
+
+  beforeEach(() => {
+    parser = new NodesetParser();
+  });
+
+  describe('parseNodeset', () => {
+    it('should parse a basic nodeset XML successfully', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <NamespaceUris>
+            <Uri>http://example.com/UA</Uri>
+          </NamespaceUris>
+          <UAObject NodeId="ns=1;i=1" BrowseName="TestObject">
+            <DisplayName>Test Object</DisplayName>
+          </UAObject>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(xml, 'test.xml');
+
+      expect(result).toBeDefined();
+      expect(result.fileName).toBe('test.xml');
+      expect(result.namespaceUri).toBe('http://example.com/UA');
+      expect(result.nodes.size).toBeGreaterThan(0);
+    });
+
+    it('should throw error on invalid XML', async () => {
+      const invalidXml = `<Invalid>Not a valid nodeset</Invalid>`;
+
+      await expect(parser.parseNodeset(invalidXml, 'invalid.xml')).rejects.toThrow(
+        'Invalid nodeset format: UANodeSet element not found'
+      );
+    });
+
+    it('should throw error on XML parsing error', async () => {
+      const malformedXml = `<?xml version="1.0"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <UAObject NodeId="ns=1;i=1">
+            <DisplayName>Unclosed tag
+          </UAObject>`;
+
+      await expect(parser.parseNodeset(malformedXml, 'malformed.xml')).rejects.toThrow();
+    });
+
+    it('should handle missing NamespaceUris element', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <UAObject NodeId="ns=1;i=1" BrowseName="TestObject">
+            <DisplayName>Test Object</DisplayName>
+          </UAObject>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(xml, 'test.xml');
+
+      expect(result.namespaceUri).toBe('http://opcfoundation.org/UA/');
+    });
+
+    it('should parse multiple node types', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <NamespaceUris>
+            <Uri>http://example.com/UA</Uri>
+          </NamespaceUris>
+          <UAObject NodeId="ns=1;i=1" BrowseName="Object1">
+            <DisplayName>Object 1</DisplayName>
+          </UAObject>
+          <UAVariable NodeId="ns=1;i=2" BrowseName="Variable1">
+            <DisplayName>Variable 1</DisplayName>
+          </UAVariable>
+          <UAMethod NodeId="ns=1;i=3" BrowseName="Method1">
+            <DisplayName>Method 1</DisplayName>
+          </UAMethod>
+          <UAObjectType NodeId="ns=1;i=4" BrowseName="ObjectType1">
+            <DisplayName>Object Type 1</DisplayName>
+          </UAObjectType>
+          <UAVariableType NodeId="ns=1;i=5" BrowseName="VariableType1">
+            <DisplayName>Variable Type 1</DisplayName>
+          </UAVariableType>
+          <UAReferenceType NodeId="ns=1;i=6" BrowseName="ReferenceType1">
+            <DisplayName>Reference Type 1</DisplayName>
+          </UAReferenceType>
+          <UADataType NodeId="ns=1;i=7" BrowseName="DataType1">
+            <DisplayName>Data Type 1</DisplayName>
+          </UADataType>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(xml, 'test.xml');
+
+      expect(result.nodes.size).toBe(7);
+      expect(result.nodes.get('ns=1;i=1')?.nodeClass).toBe(NodeClass.Object);
+      expect(result.nodes.get('ns=1;i=2')?.nodeClass).toBe(NodeClass.Variable);
+      expect(result.nodes.get('ns=1;i=3')?.nodeClass).toBe(NodeClass.Method);
+      expect(result.nodes.get('ns=1;i=4')?.nodeClass).toBe(NodeClass.ObjectType);
+      expect(result.nodes.get('ns=1;i=5')?.nodeClass).toBe(NodeClass.VariableType);
+      expect(result.nodes.get('ns=1;i=6')?.nodeClass).toBe(NodeClass.ReferenceType);
+      expect(result.nodes.get('ns=1;i=7')?.nodeClass).toBe(NodeClass.DataType);
+    });
+
+    it('should parse node with attributes', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <UAVariable NodeId="ns=1;i=1" BrowseName="Var1" DataType="ns=0;i=5" ValueRank="1">
+            <DisplayName>Variable 1</DisplayName>
+            <Description>Test variable</Description>
+          </UAVariable>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(xml, 'test.xml');
+      const node = result.nodes.get('ns=1;i=1');
+
+      expect(node?.browseName).toBe('Var1');
+      expect(node?.displayName).toBe('Variable 1');
+      expect(node?.description).toBe('Test variable');
+      expect(node?.valueRank).toBe(1);
+      expect(node?.dataType).toBeDefined();
+    });
+
+    it('should parse aliases', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <Aliases>
+            <Alias Alias="BaseDataVariableType">ns=0;i=30</Alias>
+            <Alias Alias="HasComponent">ns=0;i=47</Alias>
+          </Aliases>
+          <UAVariable NodeId="ns=1;i=1" BrowseName="Var1">
+            <DisplayName>Variable 1</DisplayName>
+          </UAVariable>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(xml, 'test.xml');
+
+      expect(result.nodes.size).toBe(1);
+      const node = result.nodes.get('ns=1;i=1');
+      expect(node?.nodeId).toBe('ns=1;i=1');
+    });
+
+    it('should parse references', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <Aliases>
+            <Alias Alias="HasComponent">ns=0;i=47</Alias>
+          </Aliases>
+          <UAObject NodeId="ns=1;i=1" BrowseName="Parent">
+            <DisplayName>Parent Object</DisplayName>
+            <References>
+              <Reference ReferenceType="HasComponent" IsForward="true">ns=1;i=2</Reference>
+              <Reference ReferenceType="HasProperty" IsForward="true">ns=1;i=3</Reference>
+            </References>
+          </UAObject>
+          <UAObject NodeId="ns=1;i=2" BrowseName="Child">
+            <DisplayName>Child Object</DisplayName>
+          </UAObject>
+          <UAVariable NodeId="ns=1;i=3" BrowseName="Prop">
+            <DisplayName>Property</DisplayName>
+          </UAVariable>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(xml, 'test.xml');
+      const parentNode = result.nodes.get('ns=1;i=1');
+
+      expect(parentNode?.references.length).toBe(2);
+      expect(parentNode?.references[0].referenceType).toBe('HasComponent');
+      expect(parentNode?.references[0].targetNodeId).toBe('ns=1;i=2');
+      expect(parentNode?.references[0].isForward).toBe(true);
+      expect(parentNode?.references[1].referenceType).toBe('HasProperty');
+    });
+
+    it('should build parent-child hierarchy', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <UAObject NodeId="ns=1;i=1" BrowseName="Parent">
+            <DisplayName>Parent</DisplayName>
+            <References>
+              <Reference ReferenceType="HasComponent" IsForward="true">ns=1;i=2</Reference>
+              <Reference ReferenceType="HasComponent" IsForward="true">ns=1;i=3</Reference>
+            </References>
+          </UAObject>
+          <UAObject NodeId="ns=1;i=2" BrowseName="Child1">
+            <DisplayName>Child 1</DisplayName>
+          </UAObject>
+          <UAVariable NodeId="ns=1;i=3" BrowseName="Child2">
+            <DisplayName>Child 2</DisplayName>
+          </UAVariable>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(xml, 'test.xml');
+      const parentNode = result.nodes.get('ns=1;i=1');
+
+      expect(parentNode?.children?.length).toBe(2);
+      expect(parentNode?.children?.[0].nodeId).toBe('ns=1;i=2');
+      expect(parentNode?.children?.[1].nodeId).toBe('ns=1;i=3');
+    });
+
+    it('should handle Organizes references in hierarchy', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <UAObject NodeId="ns=1;i=1" BrowseName="Folder">
+            <DisplayName>Folder</DisplayName>
+            <References>
+              <Reference ReferenceType="Organizes" IsForward="true">ns=1;i=2</Reference>
+            </References>
+          </UAObject>
+          <UAObject NodeId="ns=1;i=2" BrowseName="Item">
+            <DisplayName>Item</DisplayName>
+          </UAObject>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(xml, 'test.xml');
+      const folderNode = result.nodes.get('ns=1;i=1');
+
+      expect(folderNode?.children?.length).toBe(1);
+      expect(folderNode?.children?.[0].nodeId).toBe('ns=1;i=2');
+    });
+
+    it('should handle HasProperty references in hierarchy', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <UAVariable NodeId="ns=1;i=1" BrowseName="Variable">
+            <DisplayName>Variable</DisplayName>
+            <References>
+              <Reference ReferenceType="HasProperty" IsForward="true">ns=1;i=2</Reference>
+            </References>
+          </UAVariable>
+          <UAVariable NodeId="ns=1;i=2" BrowseName="Property">
+            <DisplayName>Property</DisplayName>
+          </UAVariable>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(xml, 'test.xml');
+      const variableNode = result.nodes.get('ns=1;i=1');
+
+      expect(variableNode?.children?.length).toBe(1);
+      expect(variableNode?.children?.[0].nodeId).toBe('ns=1;i=2');
+    });
+
+    it('should organize types into categories', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <UADataType NodeId="ns=1;i=1" BrowseName="DataType1">
+            <DisplayName>Data Type 1</DisplayName>
+          </UADataType>
+          <UAReferenceType NodeId="ns=1;i=2" BrowseName="RefType1">
+            <DisplayName>Reference Type 1</DisplayName>
+          </UAReferenceType>
+          <UAVariableType NodeId="ns=1;i=3" BrowseName="VarType1">
+            <DisplayName>Variable Type 1</DisplayName>
+          </UAVariableType>
+          <UAObjectType NodeId="ns=1;i=4" BrowseName="ObjType1">
+            <DisplayName>Object Type 1</DisplayName>
+          </UAObjectType>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(xml, 'test.xml');
+
+      // Check that rootNodes contains category nodes
+      expect(result.rootNodes.length).toBeGreaterThan(0);
+      
+      const categoryNames = result.rootNodes.map(node => node.browseName);
+      expect(categoryNames).toContain('DataTypes');
+      expect(categoryNames).toContain('ReferenceTypes');
+      expect(categoryNames).toContain('VariableTypes');
+      expect(categoryNames).toContain('ObjectTypes');
+    });
+
+    it('should handle derived from (HasSubtype) references', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <UAObjectType NodeId="ns=1;i=1" BrowseName="DerivedType">
+            <DisplayName>Derived Type</DisplayName>
+            <References>
+              <Reference ReferenceType="HasSubtype" IsForward="false">ns=0;i=58</Reference>
+            </References>
+          </UAObjectType>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(xml, 'test.xml');
+      const node = result.nodes.get('ns=1;i=1');
+
+      expect(node?.derivedFrom).toBeDefined();
+    });
+
+    it('should handle TypeDefinition references', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <Aliases>
+            <Alias Alias="BaseDataVariableType">ns=0;i=30</Alias>
+          </Aliases>
+          <UAVariable NodeId="ns=1;i=1" BrowseName="Variable">
+            <DisplayName>Variable</DisplayName>
+            <References>
+              <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=0;i=30</Reference>
+            </References>
+          </UAVariable>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(xml, 'test.xml');
+      const node = result.nodes.get('ns=1;i=1');
+
+      expect(node?.typeDefinition).toBeDefined();
+    });
+
+    it('should handle ModellingRule references', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <Aliases>
+            <Alias Alias="Mandatory">ns=0;i=80</Alias>
+          </Aliases>
+          <UAVariable NodeId="ns=1;i=1" BrowseName="Variable">
+            <DisplayName>Variable</DisplayName>
+            <References>
+              <Reference ReferenceType="HasModellingRule" IsForward="true">ns=0;i=80</Reference>
+            </References>
+          </UAVariable>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(xml, 'test.xml');
+      const node = result.nodes.get('ns=1;i=1');
+
+      expect(node?.modellingRule).toBeDefined();
+    });
+
+    it('should handle reference nodesets', async () => {
+      const referenceXml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <Aliases>
+            <Alias Alias="BaseDataType">ns=0;i=24</Alias>
+          </Aliases>
+          <UADataType NodeId="ns=0;i=24" BrowseName="BaseDataType">
+            <DisplayName>BaseDataType</DisplayName>
+          </UADataType>
+        </UANodeSet>`;
+
+      const mainXml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <Aliases>
+            <Alias Alias="BaseDataType">ns=0;i=24</Alias>
+          </Aliases>
+          <UADataType NodeId="ns=1;i=1" BrowseName="CustomType">
+            <DisplayName>Custom Type</DisplayName>
+          </UADataType>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(mainXml, 'test.xml', [referenceXml]);
+
+      expect(result.nodes.size).toBe(1);
+      expect(result.nodes.get('ns=1;i=1')).toBeDefined();
+    });
+
+    it('should handle node with no NodeId gracefully', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <UAObject BrowseName="NoId">
+            <DisplayName>No ID Object</DisplayName>
+          </UAObject>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(xml, 'test.xml');
+
+      // Node without NodeId should be skipped
+      expect(result.nodes.size).toBe(0);
+    });
+
+    it('should handle DisplayName from child element', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <UAObject NodeId="ns=1;i=1" BrowseName="Object1">
+            <DisplayName>
+              <Text>Test Display Name</Text>
+            </DisplayName>
+          </UAObject>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(xml, 'test.xml');
+      const node = result.nodes.get('ns=1;i=1');
+
+      expect(node?.displayName).toBe('Test Display Name');
+    });
+
+    it('should handle backward references (IsForward=false)', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <UAObject NodeId="ns=1;i=1" BrowseName="Object1">
+            <DisplayName>Object 1</DisplayName>
+            <References>
+              <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=2</Reference>
+            </References>
+          </UAObject>
+          <UAObject NodeId="ns=1;i=2" BrowseName="Parent">
+            <DisplayName>Parent Object</DisplayName>
+          </UAObject>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(xml, 'test.xml');
+      const node = result.nodes.get('ns=1;i=1');
+
+      expect(node?.references[0].isForward).toBe(false);
+      // Backward references should not be added to children
+      expect(node?.children?.length || 0).toBe(0);
+    });
+
+    it('should create root nodes with proper file metadata', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <NamespaceUris>
+            <Uri>http://custom.com/UA</Uri>
+          </NamespaceUris>
+          <UADataType NodeId="ns=1;i=1" BrowseName="Type1">
+            <DisplayName>Type 1</DisplayName>
+          </UADataType>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(xml, 'custom.xml');
+
+      expect(result.fileName).toBe('custom.xml');
+      expect(result.namespaceUri).toBe('http://custom.com/UA');
+      expect(result.namespaceIndex).toBe(1);
+    });
+
+    it('should categorize EventTypes separately', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <UAObjectType NodeId="ns=1;i=1" BrowseName="BaseEventType">
+            <DisplayName>Base Event Type</DisplayName>
+          </UAObjectType>
+          <UAObjectType NodeId="ns=1;i=2" BrowseName="CustomEventType">
+            <DisplayName>Custom Event Type</DisplayName>
+            <References>
+              <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=1</Reference>
+            </References>
+          </UAObjectType>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(xml, 'test.xml');
+
+      // Should have categories for both EventTypes and ObjectTypes (if any non-event ObjectTypes exist)
+      const categoryNames = result.rootNodes.map(node => node.browseName);
+      expect(categoryNames.length).toBeGreaterThan(0);
+    });
+
+    it('should handle complex nodeset with multiple relationships', async () => {
+      const xml = `<?xml version="1.0" encoding="utf-8"?>
+        <UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+          <Aliases>
+            <Alias Alias="HasComponent">ns=0;i=47</Alias>
+            <Alias Alias="HasProperty">ns=0;i=46</Alias>
+            <Alias Alias="HasTypeDefinition">ns=0;i=40</Alias>
+          </Aliases>
+          <UAObject NodeId="ns=1;i=1" BrowseName="ComplexObject">
+            <DisplayName>Complex Object</DisplayName>
+            <References>
+              <Reference ReferenceType="HasComponent" IsForward="true">ns=1;i=2</Reference>
+              <Reference ReferenceType="HasProperty" IsForward="true">ns=1;i=3</Reference>
+              <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=4</Reference>
+            </References>
+          </UAObject>
+          <UAVariable NodeId="ns=1;i=2" BrowseName="SubComponent">
+            <DisplayName>Sub Component</DisplayName>
+          </UAVariable>
+          <UAVariable NodeId="ns=1;i=3" BrowseName="Property">
+            <DisplayName>Property</DisplayName>
+          </UAVariable>
+          <UAObjectType NodeId="ns=1;i=4" BrowseName="ObjectType">
+            <DisplayName>Object Type</DisplayName>
+          </UAObjectType>
+        </UANodeSet>`;
+
+      const result = await parser.parseNodeset(xml, 'test.xml');
+
+      expect(result.nodes.size).toBe(4);
+      const complexNode = result.nodes.get('ns=1;i=1');
+      expect(complexNode?.references.length).toBe(3);
+      expect(complexNode?.children?.length).toBe(2); // HasComponent and HasProperty
+      expect(complexNode?.typeDefinition).toBeDefined();
+    });
+  });
+});

--- a/src/services/nodeset-parser.service.ts
+++ b/src/services/nodeset-parser.service.ts
@@ -1,0 +1,388 @@
+import { OpcUaNode, OpcUaNodeset, NodeClass, OpcUaReference } from '@/types/opcua.types';
+
+export class NodesetParser {
+  /**
+   * Parse an OPC UA nodeset XML file with optional reference nodesets
+   */
+  async parseNodeset(xmlContent: string, fileName: string = 'unknown.xml', referenceNodesets: string[] = []): Promise<OpcUaNodeset> {
+    try {
+      const parser = new DOMParser();
+      
+      // Parse all reference nodesets first to build alias maps
+      referenceNodesets.forEach((refXml) => {
+        const refDoc = parser.parseFromString(refXml, 'text/xml');
+        const refNodeSet = refDoc.querySelector('UANodeSet');
+        if (refNodeSet) {
+          this.parseAliases(refNodeSet);
+          this.parseNodeNames(refNodeSet);
+        }
+      });
+      
+      // Parse main nodeset
+      const xmlDoc = parser.parseFromString(xmlContent, 'text/xml');
+      
+      // Check for parsing errors
+      const parserError = xmlDoc.querySelector('parsererror');
+      if (parserError) {
+        throw new Error(`Failed to parse XML: ${parserError.textContent}`);
+      }
+
+      const nodeset = this.processNodeset(xmlDoc, fileName);
+      return nodeset;
+    } catch (error) {
+      throw error instanceof Error ? error : new Error('Failed to parse nodeset');
+    }
+  }
+
+  private aliasMap: Map<string, string> = new Map();
+  private nodeNameMap: Map<string, string> = new Map();
+
+  /**
+   * Process parsed XML into OPC UA nodeset structure
+   */
+  private processNodeset(xmlDoc: Document, fileName: string): OpcUaNodeset {
+    const uaNodeSet = xmlDoc.querySelector('UANodeSet');
+    
+    if (!uaNodeSet) {
+      throw new Error('Invalid nodeset format: UANodeSet element not found');
+    }
+
+    // Extract namespace URI
+    const namespaceUrisElement = uaNodeSet.querySelector('NamespaceUris');
+    let namespaceUri = 'http://opcfoundation.org/UA/';
+    
+    if (namespaceUrisElement) {
+      const uriElement = namespaceUrisElement.querySelector('Uri');
+      if (uriElement?.textContent) {
+        namespaceUri = uriElement.textContent;
+      }
+    }
+
+    // Parse aliases
+    this.parseAliases(uaNodeSet);
+
+    const nodes = new Map<string, OpcUaNode>();
+    const rootNodes: OpcUaNode[] = [];
+
+    // Parse different node types
+    const nodeTypes = [
+      'UAObject',
+      'UAVariable',
+      'UAMethod',
+      'UAObjectType',
+      'UAVariableType',
+      'UAReferenceType',
+      'UADataType',
+      'UAView',
+    ];
+
+    nodeTypes.forEach(nodeType => {
+      const nodeElements = uaNodeSet.querySelectorAll(nodeType);
+      nodeElements.forEach((xmlNode) => {
+        const node = this.parseNode(xmlNode, nodeType);
+        if (node) {
+          nodes.set(node.nodeId, node);
+        }
+      });
+    });
+
+    // Build hierarchy
+    this.buildHierarchy(nodes);
+
+    // Create organized root structure with type categories only
+    const typeCategories = this.organizeIntoCategories(nodes);
+    rootNodes.push(...typeCategories);
+
+    return {
+      fileName,
+      namespaceUri,
+      namespaceIndex: 1,
+      nodes,
+      rootNodes,
+    };
+  }
+
+  /**
+   * Organize nodes into type categories
+   */
+  private organizeIntoCategories(nodes: Map<string, OpcUaNode>): OpcUaNode[] {
+    const categories: OpcUaNode[] = [];
+
+    // Create category nodes
+    const dataTypesCategory = this.createCategoryNode('DataTypes', NodeClass.DataType);
+    const eventTypesCategory = this.createCategoryNode('EventTypes', NodeClass.ObjectType);
+    const interfaceTypesCategory = this.createCategoryNode('InterfaceTypes', NodeClass.ObjectType);
+    const objectTypesCategory = this.createCategoryNode('ObjectTypes', NodeClass.ObjectType);
+    const referenceTypesCategory = this.createCategoryNode('ReferenceTypes', NodeClass.ReferenceType);
+    const variableTypesCategory = this.createCategoryNode('VariableTypes', NodeClass.VariableType);
+
+    // Collect type nodes
+    nodes.forEach(node => {
+      if (node.nodeClass === NodeClass.DataType) {
+        dataTypesCategory.children!.push(node);
+      } else if (node.nodeClass === NodeClass.ReferenceType) {
+        referenceTypesCategory.children!.push(node);
+      } else if (node.nodeClass === NodeClass.VariableType) {
+        variableTypesCategory.children!.push(node);
+      } else if (node.nodeClass === NodeClass.ObjectType) {
+        // Distinguish between EventTypes, InterfaceTypes, and regular ObjectTypes
+        const browseName = node.browseName.toLowerCase();
+        if (browseName.includes('event') || this.hasEventTypeReference(node)) {
+          eventTypesCategory.children!.push(node);
+        } else if (browseName.includes('interface') || this.hasInterfaceReference(node)) {
+          interfaceTypesCategory.children!.push(node);
+        } else {
+          objectTypesCategory.children!.push(node);
+        }
+      }
+    });
+
+    // Only add categories that have children
+    if (dataTypesCategory.children!.length > 0) categories.push(dataTypesCategory);
+    if (eventTypesCategory.children!.length > 0) categories.push(eventTypesCategory);
+    if (interfaceTypesCategory.children!.length > 0) categories.push(interfaceTypesCategory);
+    if (objectTypesCategory.children!.length > 0) categories.push(objectTypesCategory);
+    if (referenceTypesCategory.children!.length > 0) categories.push(referenceTypesCategory);
+    if (variableTypesCategory.children!.length > 0) categories.push(variableTypesCategory);
+
+    return categories;
+  }
+
+  /**
+   * Create a category node for organizing types
+   */
+  private createCategoryNode(name: string, nodeClass: NodeClass): OpcUaNode {
+    return {
+      nodeId: `Category_${name}`,
+      browseName: name,
+      displayName: name,
+      nodeClass,
+      references: [],
+      children: [],
+    };
+  }
+
+  /**
+   * Check if node has EventType reference
+   */
+  private hasEventTypeReference(node: OpcUaNode): boolean {
+    return node.references.some(ref => 
+      ref.referenceType === 'HasSubtype' && 
+      ref.targetNodeId.includes('EventType')
+    );
+  }
+
+  /**
+   * Check if node has Interface reference
+   */
+  private hasInterfaceReference(node: OpcUaNode): boolean {
+    return node.references.some(ref => 
+      ref.referenceType === 'HasInterface' ||
+      (ref.referenceType === 'HasSubtype' && ref.targetNodeId.includes('Interface'))
+    );
+  }
+
+  /**
+   * Parse individual node from XML
+   */
+  private parseNode(xmlNode: Element, nodeType: string): OpcUaNode | null {
+    const nodeId = xmlNode.getAttribute('NodeId');
+    if (!nodeId) {
+      return null;
+    }
+
+    const nodeClass = this.getNodeClass(nodeType);
+    
+    const displayName = this.getElementText(xmlNode, 'DisplayName');
+    const description = this.getElementText(xmlNode, 'Description');
+    const browseName = xmlNode.getAttribute('BrowseName') || displayName;
+
+    const references: OpcUaReference[] = [];
+    const referencesElement = xmlNode.querySelector('References');
+    if (referencesElement) {
+      const refElements = referencesElement.querySelectorAll('Reference');
+      refElements.forEach((ref) => {
+        const targetNodeId = ref.textContent?.trim();
+        if (targetNodeId) {
+          references.push({
+            referenceType: ref.getAttribute('ReferenceType') || 'References',
+            isForward: ref.getAttribute('IsForward') !== 'false',
+            targetNodeId,
+          });
+        }
+      });
+    }
+
+    const dataType = xmlNode.getAttribute('DataType') || undefined;
+    const valueRankStr = xmlNode.getAttribute('ValueRank');
+    const valueRank = valueRankStr ? parseInt(valueRankStr) : undefined;
+    const parentNodeId = xmlNode.getAttribute('ParentNodeId') || undefined;
+
+    const derivedFromId = this.findDerivedFrom(references);
+    const derivedFromName = derivedFromId ? this.resolveNodeId(derivedFromId) : undefined;
+
+    // Find TypeDefinition reference
+    const typeDefRef = references.find(
+      ref => ref.referenceType === 'HasTypeDefinition' && ref.isForward
+    );
+    const typeDefinitionName = typeDefRef ? this.resolveNodeId(typeDefRef.targetNodeId) : undefined;
+
+    // Find ModellingRule reference
+    const modellingRuleRef = references.find(
+      ref => ref.referenceType === 'HasModellingRule' && ref.isForward
+    );
+    const modellingRuleName = modellingRuleRef ? this.resolveNodeId(modellingRuleRef.targetNodeId) : undefined;
+
+    const node: OpcUaNode = {
+      nodeId,
+      browseName,
+      displayName,
+      nodeClass,
+      description,
+      dataType: dataType ? this.resolveNodeId(dataType) : undefined,
+      valueRank,
+      modellingRule: modellingRuleName,
+      type: parentNodeId ? this.resolveNodeId(parentNodeId) : undefined,
+      typeDefinition: typeDefinitionName,
+      derivedFrom: derivedFromName,
+      references,
+      children: [],
+    };
+
+    return node;
+  }
+
+  /**
+   * Build parent-child hierarchy based on references
+   */
+  private buildHierarchy(nodes: Map<string, OpcUaNode>): void {
+    nodes.forEach(node => {
+      node.references.forEach(ref => {
+        if (
+          (ref.referenceType === 'HasComponent' || 
+           ref.referenceType === 'Organizes' ||
+           ref.referenceType === 'HasProperty') &&
+          ref.isForward
+        ) {
+          const childNode = nodes.get(ref.targetNodeId);
+          if (childNode && node.children) {
+            node.children.push(childNode);
+          }
+        }
+      });
+    });
+  }
+
+  /**
+   * Extract derived from information from references
+   */
+  private findDerivedFrom(references: OpcUaReference[]): string | undefined {
+    const hasSubtype = references.find(
+      ref => ref.referenceType === 'HasSubtype' && !ref.isForward
+    );
+    return hasSubtype?.targetNodeId;
+  }
+
+  /**
+   * Get NodeClass enum from XML node type
+   */
+  private getNodeClass(nodeType: string): NodeClass {
+    const mapping: Record<string, NodeClass> = {
+      UAObject: NodeClass.Object,
+      UAVariable: NodeClass.Variable,
+      UAMethod: NodeClass.Method,
+      UAObjectType: NodeClass.ObjectType,
+      UAVariableType: NodeClass.VariableType,
+      UAReferenceType: NodeClass.ReferenceType,
+      UADataType: NodeClass.DataType,
+      UAView: NodeClass.View,
+    };
+    return mapping[nodeType] || NodeClass.Object;
+  }
+
+  /**
+   * Parse aliases from the nodeset
+   */
+  private parseAliases(uaNodeSet: Element): void {
+    const aliasesElement = uaNodeSet.querySelector('Aliases');
+    if (!aliasesElement) return;
+    
+    const aliasElements = aliasesElement.querySelectorAll('Alias');
+    aliasElements.forEach((alias) => {
+      const aliasName = alias.getAttribute('Alias');
+      const nodeId = alias.textContent?.trim();
+      if (aliasName && nodeId) {
+        this.aliasMap.set(nodeId, aliasName);
+      }
+    });
+  }
+
+  /**
+   * Parse node names from nodesets to build a lookup map
+   */
+  private parseNodeNames(uaNodeSet: Element): void {
+    const nodeTypes = [
+      'UAObject',
+      'UAVariable',
+      'UAMethod',
+      'UAObjectType',
+      'UAVariableType',
+      'UAReferenceType',
+      'UADataType',
+      'UAView',
+    ];
+
+    nodeTypes.forEach(nodeType => {
+      const nodeElements = uaNodeSet.querySelectorAll(nodeType);
+      nodeElements.forEach((xmlNode) => {
+        const nodeId = xmlNode.getAttribute('NodeId');
+        const browseName = xmlNode.getAttribute('BrowseName');
+        
+        if (nodeId && browseName) {
+          // Store the browse name for this node ID
+          this.nodeNameMap.set(nodeId, browseName);
+        }
+      });
+    });
+  }
+
+  /**
+   * Resolve node ID to human-readable name using aliases and node names
+   */
+  private resolveNodeId(nodeId: string): string {
+    if (!nodeId) return '';
+    
+    // Check if we have an alias for this node ID
+    if (this.aliasMap.has(nodeId)) {
+      return this.aliasMap.get(nodeId)!;
+    }
+    
+    // Check if we have a node name for this node ID
+    if (this.nodeNameMap.has(nodeId)) {
+      return this.nodeNameMap.get(nodeId)!;
+    }
+    
+    // Otherwise, just return the last part after the colon or the full ID
+    const parts = nodeId.split(':');
+    return parts[parts.length - 1] || nodeId;
+  }
+
+  /**
+   * Get text content from a child element
+   */
+  private getElementText(parent: Element, tagName: string): string {
+    const element = parent.querySelector(tagName);
+    if (!element) return '';
+    
+    // Try to get text from child element first
+    const textElement = element.querySelector('Text');
+    if (textElement?.textContent) {
+      return textElement.textContent.trim();
+    }
+    
+    // Otherwise get direct text content
+    return element.textContent?.trim() || '';
+  }
+}
+
+export const nodesetParser = new NodesetParser();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,0 @@
-export * from './opcua.types';

--- a/src/types/opcua.types.ts
+++ b/src/types/opcua.types.ts
@@ -52,3 +52,12 @@ export interface NodesetMetadata {
   nodeCount: number;
   loadedAt: Date;
 }
+
+// OPC UA Nodeset
+export interface OpcUaNodeset {
+  fileName: string;
+  namespaceUri: string;
+  namespaceIndex: number;
+  nodes: Map<string, OpcUaNode>;
+  rootNodes: OpcUaNode[];
+}


### PR DESCRIPTION
### Feature: Implement OPC UA Nodeset XML Parser

- [x] Parse OPC UA nodeset XML files (nodeset2.xml format)
- [x] Extract all node types: ObjectType, VariableType, DataType, ReferenceType, Objects, Variables, Methods
- [x] Extract node attributes: NodeId, BrowseName, DisplayName, NodeClass, Description
- [x] Parse and maintain node references: HasComponent, HasProperty, HasTypeDefinition, Organizes, etc.
- [x] Build internal hierarchical data model with relationships
- [x] Handle namespaces and namespace references correctly
- [x] Provide type definitions for parsed OPC UA nodes
- [x] Return parsed data in a structured format ready for UI consumption
- [x] Include error handling with meaningful error messages for invalid XML